### PR TITLE
State default sort order on missing values

### DIFF
--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -167,7 +167,10 @@ scripts and sorting by geo distance.
 The `missing` parameter specifies how docs which are missing
 the field should be treated: The `missing` value can be
 set to `_last`, `_first`, or a custom value (that
-will be used for missing docs as the sort value). For example:
+will be used for missing docs as the sort value).
+The default is `_last`.
+
+For example:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
According to https://github.com/elastic/elasticsearch/blob/baa2d51e599bdb901e472d15cc0251e6712c1d25/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java#L143 the default value is `_last`.
